### PR TITLE
add Open boleto in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ Espaço para divulgação de projetos open-source brasileiros.
 | [AtomicReact](https://github.com/AtomicReact/AtomicReact)                                    | Javascript           | [documentação](https://atomicreact.js.org)                                                                          |
 | [Funny algorithms](https://github.com/ReciHub/FunnyAlgorithms)                               | Múltiplas linguagens |
 | [Board](https://github.com/lucasnuic/board)                                                  | Múltiplas linguagens |
-| [krsp](https://github.com/lucasnuic/krsp)                                                    | Python |
+| [krsp](https://github.com/lucasnuic/krsp)                                                    | Python               |
+| [Open Boleto](https://github.com/openboleto/openboleto)                                      | PHP                  |      
 
 <div id='license'></div>
 


### PR DESCRIPTION
Mais uma colaboração aqui para a comunidade opensource-br. adicionei o link de referência ao openboleto-br que é um projeto de biblioteca que gera boleto e é feita por devs do brasil.